### PR TITLE
Dashboard

### DIFF
--- a/python/ray/dashboard/dashboard.py
+++ b/python/ray/dashboard/dashboard.py
@@ -1,0 +1,310 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import aiohttp.web
+import argparse
+import datetime
+import json
+import logging
+import os
+import secrets
+import socket
+import threading
+import traceback
+import yaml
+
+from pathlib import Path
+from collections import Counter
+from typing import Dict
+
+import ray.ray_constants as ray_constants
+import ray.utils
+
+# Logger for this module. It should be configured at the entry point
+# into the program using Ray. Ray provides a default configuration at
+# entry/init points.
+logger = logging.getLogger(__name__)
+
+HTTP_PORT = 8080
+
+
+def to_unix_time(dt):
+    return (dt - datetime.datetime(1970, 1, 1)).total_seconds()
+
+
+class Dashboard(object):
+    """A dashboard process for monitoring Ray nodes.
+
+    This dashboard is made up of a REST API which collates data published by
+        Reporter processes on nodes into a json structure, and a webserver
+        which polls said API for display purposes.
+
+    Attributes:
+        redis_client: A client used to communicate with the Redis server.
+    """
+
+    def __init__(self, redis_address, redis_password=None):
+        """Initialize the dashboard object."""
+        self.ip = socket.gethostbyname(socket.gethostname())
+        self.port = HTTP_PORT
+        self.token = secrets.token_hex(32)  # 256-bit random token
+        self.node_stats = NodeStats(redis_address, redis_password)
+
+        self.app = aiohttp.web.Application(middlewares=[self.auth_middleware])
+        self.setup_routes()
+
+    @aiohttp.web.middleware
+    async def auth_middleware(self, req, handler):
+        def valid_token(req):
+            # If the cookie token is correct, accept that.
+            try:
+                if req.cookies["token"] == self.token:
+                    return True
+            except KeyError:
+                pass
+
+            # If the query token is correct, accept that.
+            try:
+                if req.query["token"] == self.token:
+                    return True
+            except KeyError:
+                pass
+
+            # Reject.
+            logger.warning("Dashboard: rejected an invalid token")
+            return False
+
+        # Check that the token is present, either in query or as cookie.
+        if not valid_token(req):
+            return aiohttp.web.Response(status=401, text="401 Unauthorized")
+
+        resp = await handler(req)
+        resp.cookies["token"] = self.token
+        return resp
+
+    def setup_routes(self):
+        def forbidden() -> aiohttp.web.Response:
+            return aiohttp.web.Response(
+                status=403,
+                text="403 Forbidden"
+            )
+
+        def get_forbidden(_) -> aiohttp.web.Response:
+            return forbidden()
+
+        async def get_index(req) -> aiohttp.web.Response:
+            return aiohttp.web.FileResponse(os.path.join(
+                os.path.dirname(os.path.abspath(__file__)),
+                "index.html"
+            ))
+
+        async def get_resource(req) -> aiohttp.web.Response:
+            try:
+                path = req.match_info["x"]
+            except KeyError:
+                return forbidden()
+
+            if path not in ["main.css", "main.js"]:
+                return forbidden()
+
+            return aiohttp.web.FileResponse(os.path.join(
+                os.path.dirname(os.path.abspath(__file__)),
+                "res/{}".format(path)
+            ))
+
+        async def json_response(result=None, error=None, ts=None) -> aiohttp.web.Response:
+            if ts is None:
+                ts = datetime.datetime.utcnow()
+
+            return aiohttp.web.json_response({
+                "result": result,
+                "timestamp": to_unix_time(ts),
+                "error": error,
+            })
+
+        async def ray_config(_) -> aiohttp.web.Response:
+            try:
+                with open(Path("~/ray_bootstrap_config.yaml").expanduser()) as f:
+                    cfg = yaml.load(f)
+            except Exception:
+                return await json_response(error="No config")
+
+            D = {
+                "min_workers": cfg["min_workers"],
+                "max_workers": cfg["max_workers"],
+                "initial_workers": cfg["initial_workers"],
+                "idle_timeout_minutes": cfg["idle_timeout_minutes"],
+            }
+
+            try:
+                D["head_type"] = cfg["head_node"]["InstanceType"]
+            except KeyError:
+                D["head_type"] = "unknown"
+
+            try:
+                D["worker_type"] = cfg["worker_nodes"]["InstanceType"]
+            except KeyError:
+                D["worker_type"] = "unknown"
+
+            return await json_response(result=D)
+
+        async def node_info(req) -> aiohttp.web.Response:
+            now = datetime.datetime.utcnow()
+            D = self.node_stats.get_node_stats()
+            return await json_response(result=D, ts=now)
+
+        self.app.router.add_get("/", get_index)
+        self.app.router.add_get("/index.html", get_index)
+        self.app.router.add_get("/index.htm", get_index)
+        self.app.router.add_get("/res/{x}", get_resource)
+
+        self.app.router.add_get("/api/node_info", node_info)
+        self.app.router.add_get("/api/super_client_table", node_info)
+        self.app.router.add_get("/api/ray_config", ray_config)
+
+        self.app.router.add_get("/{_}", get_forbidden)
+
+    def log_dashboard_url(self):
+        url = "http://{}:{}?token={}".format(self.ip, self.port, self.token)
+        with open("/tmp/ray/dashboard_url", "w") as f:
+            f.write(url)
+        print("Dashboard running on {}".format(url))
+
+    def run(self):
+        self.log_dashboard_url()
+        self.node_stats.start()
+        aiohttp.web.run_app(self.app, host=self.ip, port=self.port)
+
+
+class NodeStats(threading.Thread):
+    def __init__(self, redis_address, redis_password=None):
+        self.redis_key = "{}.*".format(ray.gcs_utils.REPORTER_CHANNEL)
+        self.redis_client = ray.services.create_redis_client(
+            redis_address, password=redis_password)
+
+        self._node_stats = {}
+        self._node_stats_lock = threading.Lock()
+        super().__init__()
+
+    def calculate_totals(self) -> Dict:
+        total_cpus = 0
+        total_workers = 0
+        total_load = 0
+        total_storage_used = 0
+        total_storage_total = 0
+        total_ram_used = 0
+        total_ram_total = 0
+
+        for v in self._node_stats.values():
+            total_cpus += v["cpus"][0]
+            total_workers += len(v["workers"])
+            total_load += v["load_avg"][0][0]
+            total_storage_used += v["disk"]["/"]["used"]
+            total_storage_total += v["disk"]["/"]["total"]
+            total_ram_used += (v["mem"][0] - v["mem"][1])
+            total_ram_total += v["mem"][0]
+
+        return {
+            "cpus": total_cpus,
+            "workers": total_workers,
+            "load": total_load,
+            "storage_used": total_storage_used,
+            "storage_total": total_storage_total,
+            "ram_used": total_ram_used,
+            "ram_total": total_ram_total,
+        }
+
+    def calculate_tasks(self) -> Counter:
+        return Counter(
+            (x["name"] for y in (v["workers"] for v in self._node_stats.values()) for x in y)
+        )
+
+    def purge_outdated_stats(self):
+        def current(then, now):
+            if (now - then) > 5:
+                return False
+
+            return True
+
+        now = to_unix_time(datetime.datetime.utcnow())
+        self._node_stats = {
+            k: v
+            for k, v in self._node_stats.items()
+            if current(v["now"], now)
+        }
+
+    def get_node_stats(self) -> Dict:
+        with self._node_stats_lock:
+            self.purge_outdated_stats()
+            return {
+                "totals": self.calculate_totals(),
+                "tasks": self.calculate_tasks(),
+                "clients": self._node_stats,
+            }
+
+    def run(self):
+        p = self.redis_client.pubsub()
+        p.psubscribe(self.redis_key)
+        print("NodeStats: subscribed to {}".format(self.redis_key))
+
+        for x in p.listen():
+            print(x)
+            if x["type"] != "pmessage":
+                continue
+
+            try:
+                D = json.loads(x["data"])
+                with self._node_stats_lock:
+                    self._node_stats[D["hostname"]] = D
+            except Exception:
+                traceback.print_exc()
+                continue
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description=("Parse Redis server for the "
+                     "dashboard to connect to."))
+    parser.add_argument(
+        "--redis-address",
+        required=True,
+        type=str,
+        help="The address to use for Redis.")
+    parser.add_argument(
+        "--redis-password",
+        required=False,
+        type=str,
+        default=None,
+        help="the password to use for Redis")
+    parser.add_argument(
+        "--logging-level",
+        required=False,
+        type=str,
+        default=ray_constants.LOGGER_LEVEL,
+        choices=ray_constants.LOGGER_LEVEL_CHOICES,
+        help=ray_constants.LOGGER_LEVEL_HELP)
+    parser.add_argument(
+        "--logging-format",
+        required=False,
+        type=str,
+        default=ray_constants.LOGGER_FORMAT,
+        help=ray_constants.LOGGER_FORMAT_HELP)
+    args = parser.parse_args()
+    ray.utils.setup_logger(args.logging_level, args.logging_format)
+
+    dashboard = Dashboard(
+        args.redis_address, redis_password=args.redis_password)
+
+    try:
+        dashboard.run()
+    except Exception as e:
+        # Something went wrong, so push an error to all drivers.
+        redis_client = ray.services.create_redis_client(
+            args.redis_address, password=args.redis_password)
+        traceback_str = ray.utils.format_error_message(traceback.format_exc())
+        message = ("The dashboard on node {} failed with the following "
+                   "error:\n{}".format(os.uname()[1], traceback_str))
+        ray.utils.push_error_to_driver_through_redis(
+            redis_client, ray_constants.DASHBOARD_DIED_ERROR, message)
+        raise e

--- a/python/ray/dashboard/index.html
+++ b/python/ray/dashboard/index.html
@@ -1,0 +1,71 @@
+<!doctype html>
+
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>ray dashboard</title>
+    <meta name="description" content="ray dashboard"</meta>
+    <link rel="stylesheet" href="res/main.css">
+
+    <meta name="referrer" content="same-origin">
+    <!--
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.6.4/vue.min.js"
+    integrity="sha384-rldcjlIPDkF0mEihgyEOIFhd2NW5YL717okjKC5YF2LrqoiBeMk4tpcgbRrlDHj5"
+    crossorigin="anonymous"></script>
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/axios/0.18.0/axios.min.js"
+    integrity="sha384-U/+EF1mNzvy5eahP9DeB32duTkAmXrePwnRWtuSh1C/bHHhyR1KZCr/aGZBkctpY"
+    crossorigin="anonymous"></script>
+    -->
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.6.4/vue.js"
+    integrity="sha384-94H2I+MU5hfBDUinQG+/Y9JbHALTPlQmHO26R3Jv60MT6WWkOD5hlYNyT9ciiLsR"
+    crossorigin="anonymous"></script>
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/axios/0.18.0/axios.js"
+    integrity="sha384-i1spcL1noifN1wFk9Li9LLBO5DJoBKQCNeSsSBDyrhbZayRb2Z1NIm9jImiTJn9I"
+    crossorigin="anonymous"></script>
+</head>
+
+<body>
+    <div id="dashboard">
+        <template v-if="clients && !error">
+        <h2>Last update: {{last_update | age}} ago</h2>
+        <h2 class="totals">Nodes: {{Object.keys(clients).length}} - Load: {{totals.load.toFixed(2)}}/{{totals.workers}}/{{totals.cpus}}</h2>
+        <h2 class="totals">RAM: {{totals.ram_used | si}}/{{totals.ram_total | si}} - Storage: {{totals.storage_used | si}}/{{totals.storage_total | si}}</h2>
+        <table class="ray_node_grid">
+            <thead>
+                <tr>
+                    <th class="ip">Node IP</th>
+                    <th class="uptime">Uptime</th>
+                    <th class="workers">Workers/Cores (%)</th>
+                    <th class="mem">Memory</th>
+                    <th class="storage">Storage</th>
+                    <th class="load">Load averages</th>
+                </tr>
+            </thead>
+            <tbody>
+                <node
+                    v-for="v, k, _ in clients"
+                    :v="v" :ip="k" :key="k" :now="now"
+                ></node>
+            </tbody>
+        </table>
+        <template v-if="tasks">
+            <h2>tasks</h2>
+            <ul>
+                <li v-for="v, k, _ in tasks">{{k}}: {{v}}</li>
+            </ul>
+        </template>
+        </template>
+        <template v-if="error">
+            <h2>{{error}}</h2>
+        </template>
+        <template v-if="ray_config">
+            <h2>ray config</h2>
+            <pre>{{ray_config}}</pre>
+        </template>
+    </div>
+</body>
+
+<script src="res/main.js"></script>

--- a/python/ray/dashboard/res/main.css
+++ b/python/ray/dashboard/res/main.css
@@ -1,0 +1,45 @@
+* { font-family: sans-serif; margin: 0; padding: 0; }
+h1, h2 { text-align: center; margin: 1rem 0; }
+h1 { font-size: 3rem; margin: 0.5rem auto; text-align: center; }
+h2 { font-size: 2rem; margin: 0.3rem auto; text-align: center; }
+div#dashboard {
+    width: 80rem; margin: 1rem auto; border-radius: 1rem;
+}
+
+pre, li, h2.totals { font-family: monospace; }
+
+h3, h4, h5 { text-align: center; }
+h3 { margin: 1rem 0; font-size: 2.3rem; }
+
+tr {
+    cursor: pointer;
+}
+tr.workerlist td, tr.workerlist th {
+    height: 0.5rem;
+    font-size: 0.7rem;
+    padding: 0.3rem;
+}
+tr:hover {
+    filter: brightness(0.85);
+}
+td, th {
+    border: 0.2rem solid white;
+    padding: 0.3rem;
+    font-size: 1rem;
+    font-family: monospace;
+    text-align: center;
+    background-color: white;
+}
+
+.ip { width: 7rem; font-weight: bold; }
+.uptime { width: 8rem; }
+.workers { width: 12rem; }
+.mem { width: 14rem; }
+.storage { width: 14rem; }
+.load { width: 20rem; }
+
+.critical { background-color: magenta; }
+.bad { background-color: red; }
+.high { background-color: orange; }
+.average { background-color: limegreen; }
+.low { background-color: aquamarine; }

--- a/python/ray/dashboard/res/main.js
+++ b/python/ray/dashboard/res/main.js
@@ -1,0 +1,235 @@
+let dashboard = new Vue({
+    el: "#dashboard",
+    data: {
+        now: (new Date()).getTime() / 1000,
+        shown: {},
+        error: "loading...",
+        last_update: undefined,
+        clients: undefined,
+        totals: undefined,
+        ray_config: undefined,
+    },
+    methods: {
+        updateNodeInfo() {
+            axios.get("/api/node_info").then(function (resp) {
+                setTimeout(dashboard.updateNodeInfo, 500);
+
+                dashboard.error = resp.data.error;
+                dashboard.last_update = resp.data.timestamp;
+                if (resp.data.error) {
+                    dashboard.clients = undefined;
+                    dashboard.tasks = undefined;
+                    dashboard.totals = undefined;
+                    return;
+                }
+                dashboard.clients = resp.data.result.clients;
+                dashboard.tasks = resp.data.result.tasks;
+                dashboard.totals = resp.data.result.totals;
+            }).catch(function() {
+                setTimeout(dashboard.updateNodeInfo, 500);
+
+                dashboard.error = "request error"
+                dashboard.clients = undefined;
+                dashboard.tasks = undefined;
+                dashboard.totals = undefined;
+            });
+        },
+        updateRayConfig() {
+            axios.get("/api/ray_config").then(function (resp) {
+                setTimeout(dashboard.updateRayConfig, 10000);
+
+                if (resp.data.error) {
+                    dashboard.ray_config = undefined;
+                    return;
+                }
+                dashboard.ray_config = resp.data.result;
+            }).catch(function() {
+                setTimeout(dashboard.updateRayConfig, 10000);
+
+                dashboard.error = "request error"
+                dashboard.ray_config = undefined;
+            });
+        },
+        updateAll() {
+            this.updateNodeInfo();
+            this.updateRayConfig();
+        },
+        tickClock() {
+            this.now = (new Date()).getTime() / 1000;
+        }
+    },
+    filters: {
+        age(ts) {
+            return (dashboard.now - ts | 0) + "s";
+        },
+        si(x) {
+            let prefixes = ["B", "K", "M", "G", "T"]
+            let i = 0;
+            while (x > 1024) {
+                x /= 1024;
+                i += 1;
+            }
+            return `${x.toFixed(1)}${prefixes[i]}`;
+        },
+    },
+});
+
+Vue.component("worker-usage", {
+    props: ['cores', 'workers'],
+    computed: {
+        frac: function() {
+            return this.workers / this.cores;
+        },
+        cls: function() {
+            if (this.frac > 3) { return "critical"; }
+            if (this.frac > 2) { return "bad"; }
+            if (this.frac > 1.5) { return "high"; }
+            if (this.frac > 1) { return "average"; }
+            return "low";
+        },
+    },
+    template: `
+        <td class="workers" :class="cls">
+            {{workers}}/{{cores}} ({{(frac*100).toFixed(0)}}%)
+        </td>
+    `,
+});
+
+Vue.component("node", {
+    props: ['v', 'ip', 'now'],
+    data: function() {
+        return {
+            hidden: true,
+        };
+    },
+    computed: {
+        n_workers: function() {
+            if (this.v.workers) { return this.v.workers.length; }
+            return 0;
+        },
+        age: function() {
+            if (this.v.boot_time) {
+                let rs = this.now - this.v.boot_time | 0;
+                let s = rs % 60;
+                let m = ((rs / 60) % 60) | 0;
+                let h = (rs / 3600) | 0;
+                if (h) {
+                    return `${h}h ${m}m ${s}s`;
+                }
+                if (m) {
+                    return `${m}m ${s}s`;
+                }
+                return `${s}s`;
+            }
+            return "?"
+        },
+    },
+    methods: {
+        toggleHide: function() {
+            this.hidden = !this.hidden;
+        }
+    },
+    filters: {
+    },
+    template: `
+    <tbody v-on:click="toggleHide()">
+        <tr class="ray_node">
+            <td class="ip">{{ip}}</td>
+            <td class="uptime">{{age}}</td>
+            <worker-usage
+                :cores="v.cpus[0]"
+                :workers="n_workers"
+            ></worker-usage>
+            <usagebar v-if="v.mem"
+                :avail="v.mem[1]" :total="v.mem[0]"
+                stat="mem"
+            ></usagebar>
+            <usagebar v-if="v.disk"
+                :avail="v.disk['/'].free" :total="v.disk['/'].total"
+                stat="storage"
+            ></usagebar>
+            <loadbar
+                v-if="v.load_avg"
+                :cores="v.cpus[0]"
+                :onem="v.load_avg[0][0]"
+                :fivem="v.load_avg[0][1]"
+                :fifteenm="v.load_avg[0][2]"
+            >
+            </loadbar>
+        </tr>
+        <template v-if="!hidden && v.workers">
+            <tr class="workerlist">
+                <th>time</th>
+                <th>name</th>
+                <th>pid</th>
+                <th>uss</th>
+            </tr>
+            <tr class="workerlist" v-for="x in v.workers">
+                <td>user: {{x.cpu_times.user}}s</td>
+                <td>{{x.name}}</td>
+                <td>{{x.pid}}</td>
+                <td>{{(x.memory_full_info.uss/1048576).toFixed(0)}}MiB</td>
+            </tr>
+        </template>
+    </tbody>
+    `,
+});
+
+Vue.component("usagebar", {
+    props: ['stat', 'avail', 'total'], // e.g. free -m avail
+    computed: {
+        used: function() { return this.total - this.avail; },
+        frac: function() { return (this.total - this.avail)/this.total; },
+        cls: function() {
+            if (this.frac > 0.95) { return "critical"; }
+            if (this.frac > 0.9) { return "bad"; }
+            if (this.frac > 0.8) { return "high"; }
+            if (this.frac > 0.5) { return "average"; }
+            return "low";
+        },
+        tcls: function() {
+            return `${this.stat} ${this.cls}`;
+        }
+    },
+    filters: {
+        si(x) {
+            let prefixes = ["B", "K", "M", "G", "T"]
+            let i = 0;
+            while (x > 1024) {
+                x /= 1024;
+                i += 1;
+            }
+            return `${x.toFixed(1)}${prefixes[i]}`;
+        },
+        pct(x) {
+            return `${(x*100).toFixed(0)}%`;
+        },
+    },
+    template: `
+    <td class="usagebar" :class="tcls">
+        {{used | si}}/{{total | si}} ({{ frac | pct }})
+    </td>
+    `,
+});
+
+Vue.component("loadbar", {
+    props: ['cores', 'onem', 'fivem', 'fifteenm'],
+    computed: {
+        frac: function() { return this.onem/this.cores; },
+        cls: function() {
+            if (this.frac > 3) { return "critical"; }
+            if (this.frac > 2.5) { return "bad"; }
+            if (this.frac > 2) { return "high"; }
+            if (this.frac > 1.5) { return "average"; }
+            return "low";
+        },
+    },
+    template: `
+    <td class="load loadbar" :class="cls">
+        {{onem}} ({{frac.toFixed(2)}}), {{fivem}}, {{fifteenm}}
+    </td>
+    `,
+});
+
+setInterval(dashboard.tickClock, 1000);
+dashboard.updateAll();

--- a/python/ray/node.py
+++ b/python/ray/node.py
@@ -15,7 +15,7 @@ import ray.ray_constants as ray_constants
 from ray.tempfile_services import (
     get_logs_dir_path, get_object_store_socket_name, get_raylet_socket_name,
     new_log_monitor_log_file, new_monitor_log_file,
-    new_reporter_log_file,
+    new_reporter_log_file, new_dashboard_log_file,
     new_raylet_monitor_log_file, new_plasma_store_log_file,
     new_raylet_log_file, new_webui_log_file, set_temp_root,
     try_to_create_directory)
@@ -171,6 +171,19 @@ class Node(object):
             process_info
         ]
 
+    def start_dashboard(self):
+        """Start the dashboard."""
+        stdout_file, stderr_file = new_dashboard_log_file()
+        process_info = ray.services.start_dashboard(
+            self.redis_address,
+            stdout_file=stdout_file,
+            stderr_file=stderr_file,
+            redis_password=self._ray_params.redis_password)
+        assert ray_constants.PROCESS_TYPE_DASHBOARD not in self.all_processes
+        self.all_processes[ray_constants.PROCESS_TYPE_DASHBOARD] = [
+            process_info
+        ]
+
     def start_ui(self):
         """Start the web UI."""
         stdout_file, stderr_file = new_webui_log_file()
@@ -294,6 +307,7 @@ class Node(object):
             self.start_redis()
             self.start_monitor()
             self.start_raylet_monitor()
+            self.start_dashboard()
 
         self.start_plasma_store()
         self.start_raylet()
@@ -441,6 +455,16 @@ class Node(object):
         """
         self._kill_process_type(
             ray_constants.PROCESS_TYPE_REPORTER, check_alive=check_alive)
+
+    def kill_dashboard(self, check_alive=True):
+        """Kill the dashboard.
+
+        Args:
+            check_alive (bool): Raise an exception if the process was already
+                dead.
+        """
+        self._kill_process_type(
+            ray_constants.PROCESS_TYPE_DASHBOARD, check_alive=check_alive)
 
     def kill_monitor(self, check_alive=True):
         """Kill the monitor.

--- a/python/ray/ray_constants.py
+++ b/python/ray/ray_constants.py
@@ -55,6 +55,7 @@ REMOVED_NODE_ERROR = "node_removed"
 MONITOR_DIED_ERROR = "monitor_died"
 LOG_MONITOR_DIED_ERROR = "log_monitor_died"
 REPORTER_DIED_ERROR = "reporter_died"
+DASHBOARD_DIED_ERROR = "dashboard_died"
 
 # Abort autoscaling if more than this number of errors are encountered. This
 # is a safety feature to prevent e.g. runaway node launches.
@@ -101,6 +102,7 @@ PROCESS_TYPE_MONITOR = "monitor"
 PROCESS_TYPE_RAYLET_MONITOR = "raylet_monitor"
 PROCESS_TYPE_LOG_MONITOR = "log_monitor"
 PROCESS_TYPE_REPORTER = "reporter"
+PROCESS_TYPE_DASHBOARD = "dashboard"
 PROCESS_TYPE_WORKER = "worker"
 PROCESS_TYPE_RAYLET = "raylet"
 PROCESS_TYPE_PLASMA_STORE = "plasma_store"

--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -861,6 +861,39 @@ def start_reporter(redis_address,
     return process_info
 
 
+def start_dashboard(redis_address,
+                      stdout_file=None,
+                      stderr_file=None,
+                      redis_password=None):
+    """Start a dashboard process.
+
+    Args:
+        redis_address (str): The address of the Redis instance.
+        stdout_file: A file handle opened for writing to redirect stdout to. If
+            no redirection should happen, then this should be None.
+        stderr_file: A file handle opened for writing to redirect stderr to. If
+            no redirection should happen, then this should be None.
+        redis_password (str): The password of the redis server.
+
+    Returns:
+        ProcessInfo for the process that was started.
+    """
+    dashboard_filepath = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "dashboard/dashboard.py")
+    command = [
+        sys.executable, "-u", dashboard_filepath,
+        "--redis-address={}".format(redis_address)
+    ]
+    if redis_password:
+        command += ["--redis-password", redis_password]
+    process_info = start_ray_process(
+        command,
+        ray_constants.PROCESS_TYPE_DASHBOARD,
+        stdout_file=stdout_file,
+        stderr_file=stderr_file)
+    return process_info
+
+
 def start_ui(redis_address, stdout_file=None, stderr_file=None):
     """Start a UI process.
 

--- a/python/ray/tempfile_services.py
+++ b/python/ray/tempfile_services.py
@@ -226,6 +226,13 @@ def new_reporter_log_file():
     return reporter_stdout_file, reporter_stderr_file
 
 
+def new_dashboard_log_file():
+    """Create new logging files for the dashboard."""
+    dashboard_stdout_file, dashboard_stderr_file = new_log_files(
+        "dashboard", redirect_output=True)
+    return dashboard_stdout_file, dashboard_stderr_file
+
+
 def new_plasma_store_log_file(redirect_output):
     """Create new logging files for the plasma store."""
     plasma_store_stdout_file, plasma_store_stderr_file = new_log_files(

--- a/python/setup.py
+++ b/python/setup.py
@@ -149,6 +149,8 @@ requires = [
     # simplejson and psutil are required by the Reporter.
     "simplejson",
     "psutil",
+    # aiohttp is required by the Dashboard.
+    "aiohttp",
 ]
 
 setup(


### PR DESCRIPTION
Linked with https://github.com/longshotsyndicate/model-backtester-framework/pull/53.

This moves the dashboard into Ray proper where it deserves to live.

This comprises the aiohttp/redis backend, and Flask front-end for the Ray dashboard. It should be autoscaler-independent.