### PR TITLE
[autoscaler] Add a `request_cores` function for manual autoscaling

### DIFF
--- a/python/ray/autoscaler/autoscaler.py
+++ b/python/ray/autoscaler/autoscaler.py
@@ -25,7 +25,8 @@ from ray.autoscaler.tags import (TAG_RAY_LAUNCH_CONFIG, TAG_RAY_RUNTIME_CONFIG,
 from ray.autoscaler.updater import NodeUpdaterThread
 from ray.ray_constants import AUTOSCALER_MAX_NUM_FAILURES, \
     AUTOSCALER_MAX_LAUNCH_BATCH, AUTOSCALER_MAX_CONCURRENT_LAUNCHES, \
-    AUTOSCALER_UPDATE_INTERVAL_S, AUTOSCALER_HEARTBEAT_TIMEOUT_S
+    AUTOSCALER_UPDATE_INTERVAL_S, AUTOSCALER_HEARTBEAT_TIMEOUT_S, \
+    AUTOSCALER_RESOURCE_REQUEST_CHANNEL
 from six import string_types
 from six.moves import queue
 
@@ -47,12 +48,6 @@ CLUSTER_CONFIG_SCHEMA = {
     # The maximum number of workers nodes to launch in addition to the head
     # node. This takes precedence over min_workers.
     "max_workers": (int, REQUIRED),
-
-    # The number of workers to launch initially, in addition to the head node.
-    "initial_workers": (int, OPTIONAL),
-
-    # The mode of the autoscaler e.g. default, aggressive
-    "autoscaling_mode": (str, OPTIONAL),
 
     # The autoscaler will scale up the cluster to this target fraction of
     # resources usage. For example, if a cluster of 8 nodes is 100% busy
@@ -354,7 +349,6 @@ class StandardAutoscaler(object):
         self.num_failures = 0
         self.last_update_time = 0.0
         self.update_interval_s = update_interval_s
-        self.bringup = True
 
         # Node launchers
         self.launch_queue = queue.Queue()
@@ -379,6 +373,8 @@ class StandardAutoscaler(object):
 
         for local_path in self.config["file_mounts"].values():
             assert os.path.exists(local_path)
+
+        self.resource_requests = defaultdict(int)
 
         logger.info("StandardAutoscaler: {}".format(self.config))
 
@@ -406,10 +402,15 @@ class StandardAutoscaler(object):
         self.last_update_time = now
         num_pending = self.num_launches_pending.value
         nodes = self.workers()
-        self.log_info_string(nodes)
         self.load_metrics.prune_active_ips(
             [self.provider.internal_ip(node_id) for node_id in nodes])
         target_workers = self.target_num_workers()
+
+        if len(nodes) >= target_workers:
+            if "CPU" in self.resource_requests:
+                del self.resource_requests["CPU"]
+
+        self.log_info_string(nodes, target_workers)
 
         # Terminate any idle or out of date nodes
         last_used = self.load_metrics.last_used_time_by_ip
@@ -431,7 +432,7 @@ class StandardAutoscaler(object):
         if nodes_to_terminate:
             self.provider.terminate_nodes(nodes_to_terminate)
             nodes = self.workers()
-            self.log_info_string(nodes)
+            self.log_info_string(nodes, target_workers)
 
         # Terminate nodes if there are too many
         nodes_to_terminate = []
@@ -444,20 +445,18 @@ class StandardAutoscaler(object):
         if nodes_to_terminate:
             self.provider.terminate_nodes(nodes_to_terminate)
             nodes = self.workers()
-            self.log_info_string(nodes)
+            self.log_info_string(nodes, target_workers)
 
         # Launch new nodes if needed
         num_workers = len(nodes) + num_pending
         if num_workers < target_workers:
             max_allowed = min(self.max_launch_batch,
                               self.max_concurrent_launches - num_pending)
+
             num_launches = min(max_allowed, target_workers - num_workers)
             self.launch_new_node(num_launches)
             nodes = self.workers()
-            self.log_info_string(nodes)
-        elif self.load_metrics.num_workers_connected() >= target_workers:
-            logger.info("Ending bringup phase")
-            self.bringup = False
+            self.log_info_string(nodes, target_workers)
 
         # Process any completed updates
         completed = []
@@ -475,7 +474,7 @@ class StandardAutoscaler(object):
             # immediately trying to restart Ray on the new node.
             self.load_metrics.mark_active(self.provider.internal_ip(node_id))
             nodes = self.workers()
-            self.log_info_string(nodes)
+            self.log_info_string(nodes, target_workers)
 
         # Update nodes with out-of-date files
         T = [
@@ -522,13 +521,17 @@ class StandardAutoscaler(object):
         ideal_num_nodes = int(np.ceil(cur_used / float(target_frac)))
         ideal_num_workers = ideal_num_nodes - 1  # subtract 1 for head node
 
-        initial_workers = self.config["initial_workers"]
-        aggressive = self.config["autoscaling_mode"] == "aggressive"
-        if self.bringup:
-            ideal_num_workers = max(ideal_num_workers, initial_workers)
-        elif aggressive and cur_used > 0:
-            # If we want any workers, we want at least initial_workers
-            ideal_num_workers = max(ideal_num_workers, initial_workers)
+        # Other resources are not supported at present.
+        if "CPU" in self.resource_requests:
+            try:
+                cores_per_worker = self.config["worker_nodes"]["Resources"]["CPU"]
+            except KeyError:
+                cores_per_worker = 1  # Assume the worst
+
+            cores_desired = self.resource_requests["CPU"]
+
+            ideal_num_workers = max(ideal_num_workers,
+                int(np.ceil(cores_desired/cores_per_worker)))
 
         return min(self.config["max_workers"],
                    max(self.config["min_workers"], ideal_num_workers))
@@ -633,11 +636,11 @@ class StandardAutoscaler(object):
         return self.provider.non_terminated_nodes(
             tag_filters={TAG_RAY_NODE_TYPE: "worker"})
 
-    def log_info_string(self, nodes):
-        logger.info("StandardAutoscaler: {}".format(self.info_string(nodes)))
+    def log_info_string(self, nodes, target):
+        logger.info("StandardAutoscaler: {}".format(self.info_string(nodes, target)))
         logger.info("LoadMetrics: {}".format(self.load_metrics.info_string()))
 
-    def info_string(self, nodes):
+    def info_string(self, nodes, target):
         suffix = ""
         if self.num_launches_pending:
             suffix += " ({} pending)".format(self.num_launches_pending.value)
@@ -646,11 +649,16 @@ class StandardAutoscaler(object):
         if self.num_failed_updates:
             suffix += " ({} failed to update)".format(
                 len(self.num_failed_updates))
-        if self.bringup:
-            suffix += " (bringup=True)"
 
         return "{}/{} target nodes{}".format(
-            len(nodes), self.target_num_workers(), suffix)
+            len(nodes), target, suffix)
+
+    def request_resources(self, resources):
+        for resource, count in resources.items():
+            self.resource_requests[resource] = max(self.resource_requests[resource], count)
+
+        logger.info("StandardAutoscaler: resource_requests={}".format(
+            self.resource_requests))
 
 
 def typename(v):
@@ -782,3 +790,8 @@ def hash_runtime_conf(file_mounts, extra_objs):
         _hash_cache[conf_str] = hasher.hexdigest()
 
     return _hash_cache[conf_str]
+
+def request_cores(redis_address, cores, redis_password=None):
+    # For now this only supports CPUs. It is non blocking.
+    r = services.create_redis_client(redis_address, password=redis_password)
+    r.publish(AUTOSCALER_RESOURCE_REQUEST_CHANNEL, json.dumps({"CPU": cores}))

--- a/python/ray/autoscaler/aws/example-full.yaml
+++ b/python/ray/autoscaler/aws/example-full.yaml
@@ -9,16 +9,6 @@ min_workers: 0
 # node. This takes precedence over min_workers.
 max_workers: 2
 
-# The initial number of worker nodes to launch in addition to the head
-# node. When the cluster is first brought up (or when it is refreshed with a
-# subsequent `ray up`) this number of nodes will be started.
-initial_workers: 0
-
-# Whether or not to autoscale aggressively. If this is enabled, if at any point
-#   we would start more workers, we start at least enough to bring us to
-#   initial_workers.
-autoscaling_mode: default
-
 # This executes all commands on all nodes in the docker container,
 # and opens all the necessary ports to support the Ray cluster.
 # Empty string means disabled.

--- a/python/ray/autoscaler/aws/example-gpu-docker.yaml
+++ b/python/ray/autoscaler/aws/example-gpu-docker.yaml
@@ -9,16 +9,6 @@ min_workers: 0
 # node. This takes precedence over min_workers.
 max_workers: 2
 
-# The initial number of worker nodes to launch in addition to the head
-# node. When the cluster is first brought up (or when it is refreshed with a
-# subsequent `ray up`) this number of nodes will be started.
-initial_workers: 0
-
-# Whether or not to autoscale aggressively. If this is enabled, if at any point
-#   we would start more workers, we start at least enough to bring us to
-#   initial_workers.
-autoscaling_mode: default
-
 # This executes all commands on all nodes in the docker container,
 # and opens all the necessary ports to support the Ray cluster.
 # Empty string means disabled.

--- a/python/ray/autoscaler/aws/node_provider.py
+++ b/python/ray/autoscaler/aws/node_provider.py
@@ -169,6 +169,13 @@ class AWSNodeProvider(NodeProvider):
     def create_node(self, node_config, tags, count):
         tags = to_aws_format(tags)
         conf = node_config.copy()
+
+        # Delete unsupported keys from the node config
+        try:
+            del conf["Resources"]
+        except KeyError:
+            pass
+
         tag_pairs = [{
             "Key": TAG_RAY_CLUSTER_NAME,
             "Value": self.cluster_name,

--- a/python/ray/autoscaler/gcp/example-full.yaml
+++ b/python/ray/autoscaler/gcp/example-full.yaml
@@ -9,16 +9,6 @@ min_workers: 0
 # node. This takes precedence over min_workers.
 max_workers: 2
 
-# The initial number of worker nodes to launch in addition to the head
-# node. When the cluster is first brought up (or when it is refreshed with a
-# subsequent `ray up`) this number of nodes will be started.
-initial_workers: 0
-
-# Whether or not to autoscale aggressively. If this is enabled, if at any point
-#   we would start more workers, we start at least enough to bring us to
-#   initial_workers.
-autoscaling_mode: default
-
 # This executes all commands on all nodes in the docker container,
 # and opens all the necessary ports to support the Ray cluster.
 # Empty string means disabled.

--- a/python/ray/autoscaler/gcp/example-gpu-docker.yaml
+++ b/python/ray/autoscaler/gcp/example-gpu-docker.yaml
@@ -9,16 +9,6 @@ min_workers: 0
 # node. This takes precedence over min_workers.
 max_workers: 2
 
-# The initial number of worker nodes to launch in addition to the head
-# node. When the cluster is first brought up (or when it is refreshed with a
-# subsequent `ray up`) this number of nodes will be started.
-initial_workers: 0
-
-# Whether or not to autoscale aggressively. If this is enabled, if at any point
-#   we would start more workers, we start at least enough to bring us to
-#   initial_workers.
-autoscaling_mode: default
-
 # This executes all commands on all nodes in the docker container,
 # and opens all the necessary ports to support the Ray cluster.
 # Empty string means disabled.

--- a/python/ray/autoscaler/local/example-full.yaml
+++ b/python/ray/autoscaler/local/example-full.yaml
@@ -1,8 +1,6 @@
 cluster_name: default
 min_workers: 0
 max_workers: 0
-initial_workers: 0
-autoscaling_mode: default
 docker:
     image: ""
     container_name: ""

--- a/python/ray/dashboard/dashboard.py
+++ b/python/ray/dashboard/dashboard.py
@@ -140,8 +140,6 @@ class Dashboard(object):
             D = {
                 "min_workers": cfg["min_workers"],
                 "max_workers": cfg["max_workers"],
-                "initial_workers": cfg["initial_workers"],
-                "autoscaling_mode": cfg["autoscaling_mode"],
                 "idle_timeout_minutes": cfg["idle_timeout_minutes"],
             }
 

--- a/python/ray/monitor.py
+++ b/python/ray/monitor.py
@@ -7,6 +7,7 @@ import logging
 import os
 import time
 import traceback
+import json
 
 import redis
 
@@ -216,6 +217,16 @@ class Monitor(object):
                         binary_to_hex(driver_id)))
         self._xray_clean_up_entries_for_driver(driver_id)
 
+    def autoscaler_resource_request_handler(self, _, data):
+        if not self.autoscaler:
+            return
+
+        try:
+            self.autoscaler.request_resources(json.loads(data))
+        except Exception:
+            # We don't want this to kill the monitor.
+            traceback.print_exc()
+
     def process_messages(self, max_messages=10000):
         """Process all messages ready in the subscription channels.
 
@@ -245,6 +256,8 @@ class Monitor(object):
                 elif channel == ray.gcs_utils.XRAY_DRIVER_CHANNEL:
                     # Handles driver death.
                     message_handler = self.xray_driver_removed_handler
+                elif channel == ray.ray_constants.AUTOSCALER_RESOURCE_REQUEST_CHANNEL:
+                    message_handler = self.autoscaler_resource_request_handler
                 else:
                     raise Exception("This code should be unreachable.")
 
@@ -301,6 +314,9 @@ class Monitor(object):
         # Initialize the subscription channel.
         self.subscribe(ray.gcs_utils.XRAY_HEARTBEAT_BATCH_CHANNEL)
         self.subscribe(ray.gcs_utils.XRAY_DRIVER_CHANNEL)
+
+        if self.autoscaler:
+            self.subscribe(ray.ray_constants.AUTOSCALER_RESOURCE_REQUEST_CHANNEL)
 
         # TODO(rkn): If there were any dead clients at startup, we should clean
         # up the associated state in the state tables.

--- a/python/ray/ray_constants.py
+++ b/python/ray/ray_constants.py
@@ -125,3 +125,5 @@ LOG_MONITOR_MAX_OPEN_FILES = 200
 
 # A constant used as object metadata to indicate the object is raw binary.
 RAW_BUFFER_METADATA = b"RAW"
+
+AUTOSCALER_RESOURCE_REQUEST_CHANNEL = b"autoscaler_resource_request"

--- a/python/ray/tests/test_autoscaler.py
+++ b/python/ray/tests/test_autoscaler.py
@@ -106,8 +106,6 @@ SMALL_CLUSTER = {
     "cluster_name": "default",
     "min_workers": 2,
     "max_workers": 2,
-    "initial_workers": 0,
-    "autoscaling_mode": "default",
     "target_utilization_fraction": 0.8,
     "idle_timeout_minutes": 5,
     "provider": {
@@ -275,6 +273,33 @@ class AutoscalingTest(unittest.TestCase):
         autoscaler.update()
         self.waitForNodes(2)
 
+    def testManualAutoscaling(self):
+        config = SMALL_CLUSTER.copy()
+        config["min_workers"] = 0
+        config["max_workers"] = 50
+        cores_per_node = 2
+        config["worker_nodes"] = { "Resources": { "CPU": cores_per_node } }
+        config_path = self.write_config(config)
+        self.provider = MockProvider()
+        autoscaler = StandardAutoscaler(
+            config_path,
+            LoadMetrics(),
+            max_launch_batch=5,
+            max_concurrent_launches=5,
+            max_failures=0,
+            update_interval_s=0)
+        assert len(self.provider.non_terminated_nodes({})) == 0
+        autoscaler.update()
+        self.waitForNodes(0)
+        autoscaler.request_resources({ "CPU": cores_per_node*10 })
+        for _ in range(3):  # Maximum launch batch is 5
+            autoscaler.update()
+        self.waitForNodes(10)
+        autoscaler.request_resources({ "CPU": cores_per_node*30 })
+        for _ in range(4):  # Maximum launch batch is 5
+            autoscaler.update()
+        self.waitForNodes(30)
+
     def testTerminateOutdatedNodesGracefully(self):
         config = SMALL_CLUSTER.copy()
         config["min_workers"] = 5
@@ -324,80 +349,6 @@ class AutoscalingTest(unittest.TestCase):
         self.waitForNodes(6)
         autoscaler.update()
         self.waitForNodes(10)
-
-    def testInitialWorkers(self):
-        config = SMALL_CLUSTER.copy()
-        config["min_workers"] = 0
-        config["max_workers"] = 20
-        config["initial_workers"] = 10
-        config_path = self.write_config(config)
-        self.provider = MockProvider()
-        autoscaler = StandardAutoscaler(
-            config_path,
-            LoadMetrics(),
-            max_launch_batch=5,
-            max_concurrent_launches=5,
-            max_failures=0,
-            update_interval_s=0)
-        self.waitForNodes(0)
-        autoscaler.update()
-        self.waitForNodes(5)  # expected due to batch sizes and concurrency
-        autoscaler.update()
-        self.waitForNodes(10)
-        autoscaler.update()
-
-    def testAggressiveAutoscaling(self):
-        config = SMALL_CLUSTER.copy()
-        config["min_workers"] = 0
-        config["max_workers"] = 20
-        config["initial_workers"] = 10
-        config["idle_timeout_minutes"] = 0
-        config["autoscaling_mode"] = "aggressive"
-        config_path = self.write_config(config)
-
-        self.provider = MockProvider()
-        self.provider.create_node({}, {TAG_RAY_NODE_TYPE: "head"}, 1)
-        head_ip = self.provider.non_terminated_node_ips(
-            tag_filters={TAG_RAY_NODE_TYPE: "head"}, )[0]
-
-        lm = LoadMetrics()
-        lm.local_ip = head_ip
-
-        autoscaler = StandardAutoscaler(
-            config_path,
-            lm,
-            max_launch_batch=5,
-            max_concurrent_launches=5,
-            max_failures=0,
-            update_interval_s=0)
-
-        self.waitForNodes(1)
-        autoscaler.update()
-        self.waitForNodes(6)  # expected due to batch sizes and concurrency
-        autoscaler.update()
-        self.waitForNodes(11)
-
-        # Connect the head and workers to end the bringup phase
-        addrs = self.provider.non_terminated_node_ips(
-            tag_filters={TAG_RAY_NODE_TYPE: "worker"}, )
-        addrs += head_ip
-        for addr in addrs:
-            lm.update(addr, {"CPU": 2}, {"CPU": 0})
-            lm.update(addr, {"CPU": 2}, {"CPU": 2})
-        assert autoscaler.bringup
-        autoscaler.update()
-
-        assert not autoscaler.bringup
-        autoscaler.update()
-        self.waitForNodes(1)
-
-        # All of the nodes are down. Simulate some load on the head node
-        lm.update(head_ip, {"CPU": 2}, {"CPU": 0})
-
-        autoscaler.update()
-        self.waitForNodes(6)  # expected due to batch sizes and concurrency
-        autoscaler.update()
-        self.waitForNodes(11)
 
     def testDelayedLaunch(self):
         config_path = self.write_config(SMALL_CLUSTER)


### PR DESCRIPTION
This PR allows users to manually request resources for the autoscaler. It is aimed at being a more general solution to 'aggressive_autoscaling', 'initial_workers' and other such hacks.

I have removed those two options as they were originally added by me and I believe they are no longer necessary.

I have added a test for the functionality and removed the tests for now obsoleted code.

Usage:

```
redis_address = ray.init()["redis_address"]
from ray.autoscaler.autoscaler import request_cores
request_cores(redis_address, 20)  # non-blocking
```

This will then ensure that on the next autoscaler cycle, workers sufficient to run 20 tasks are made available (if not otherwise restricted e.g. by max_workers).

We are using this in production with thousands of workers and it seems able to quickly spin up 50-100 nodes on AWS.